### PR TITLE
Use GET for Public and POST for Private Methods

### DIFF
--- a/krakenapi.go
+++ b/krakenapi.go
@@ -580,7 +580,7 @@ func (api *KrakenAPI) Query(method string, data map[string]string) (interface{},
 // Execute a public method query
 func (api *KrakenAPI) queryPublic(method string, values url.Values, typ interface{}) (interface{}, error) {
 	url := fmt.Sprintf("%s/%s/public/%s", APIURL, APIVersion, method)
-	resp, err := api.doRequest(url, values, nil, typ)
+	resp, err := api.doRequest(http.MethodGet, url, values, nil, typ)
 
 	return resp, err
 }
@@ -601,18 +601,18 @@ func (api *KrakenAPI) queryPrivate(method string, values url.Values, typ interfa
 		"API-Sign": signature,
 	}
 
-	resp, err := api.doRequest(reqURL, values, headers, typ)
+	resp, err := api.doRequest(http.MethodPost, reqURL, values, headers, typ)
 
 	return resp, err
 }
 
 // doRequest executes a HTTP Request to the Kraken API and returns the result
-func (api *KrakenAPI) doRequest(reqURL string, values url.Values, headers map[string]string, typ interface{}) (interface{}, error) {
+func (api *KrakenAPI) doRequest(method string, reqURL string, values url.Values, headers map[string]string, typ interface{}) (interface{}, error) {
 
 	// Create request
-	req, err := http.NewRequest(http.MethodGet, reqURL, strings.NewReader(values.Encode()))
+	req, err := http.NewRequest(method, reqURL, strings.NewReader(values.Encode()))
 	if err != nil {
-		return nil, fmt.Errorf("Could not execute request! #1 (%s)", err.Error())
+		return nil, fmt.Errorf("Could not execute %s request to %s! #1 (%s)", method, reqURL, err.Error())
 	}
 
 	req.Header.Add("User-Agent", APIUserAgent)
@@ -623,23 +623,23 @@ func (api *KrakenAPI) doRequest(reqURL string, values url.Values, headers map[st
 	// Execute request
 	resp, err := api.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("Could not execute request! #2 (%s)", err.Error())
+		return nil, fmt.Errorf("Could not execute %s request to %s! #2 (%s)", method, reqURL, err.Error())
 	}
 	defer resp.Body.Close()
 
 	// Read request
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("Could not execute request! #3 (%s)", err.Error())
+		return nil, fmt.Errorf("Could not execute %s request to %s! #3 (%s)", method, reqURL, err.Error())
 	}
 
 	// Check mime type of response
 	mimeType, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
 	if err != nil {
-		return nil, fmt.Errorf("Could not execute request #4! (%s)", err.Error())
+		return nil, fmt.Errorf("Could not execute %s request to %s! #4 (%s)", method, reqURL, err.Error())
 	}
 	if mimeType != "application/json" {
-		return nil, fmt.Errorf("Could not execute request #5! (%s)", fmt.Sprintf("Response Content-Type is '%s', but should be 'application/json'.", mimeType))
+		return nil, fmt.Errorf("Could not execute %s request to %s! #5 (%s)", method, reqURL, fmt.Sprintf("Response Content-Type is '%s', but should be 'application/json'.", mimeType))
 	}
 
 	// Parse request
@@ -653,12 +653,12 @@ func (api *KrakenAPI) doRequest(reqURL string, values url.Values, headers map[st
 
 	err = json.Unmarshal(body, &jsonData)
 	if err != nil {
-		return nil, fmt.Errorf("Could not execute request! #6 (%s)", err.Error())
+		return nil, fmt.Errorf("Could not execute %s request to %s! #6 (%s)", method, reqURL, err.Error())
 	}
 
 	// Check for Kraken API error
 	if len(jsonData.Error) > 0 {
-		return nil, fmt.Errorf("Could not execute request! #7 (%s)", jsonData.Error)
+		return nil, fmt.Errorf("Could not execute %s request to %s! #7 (%s)", method, reqURL, jsonData.Error)
 	}
 
 	return jsonData.Result, nil


### PR DESCRIPTION
According to [Kraken's recent Changelog](https://docs.kraken.com/rest/#section/Changelog), `POST` is no longer supported for public endpoints. This PR uses the right HTTP method for public & private endpoints.